### PR TITLE
name and extension (of the selected object)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -80,11 +80,24 @@ class ExportPrefab(bpy.types.Operator, ExportHelper):
         },
         default="0"
     )
+        
+    shape_ext: EnumProperty(
+        name="Shape extension",
+        description="Which collision type to use",
+        items={
+            ("0", ".DAE", ""),
+            ("1", ".dts", ""),
+            ("2", "none", ""),
+        },
+        default="0"
+    )
 
     def draw(self, context):
         layout = self.layout
         sub = layout.row()
         sub.prop(self, "shape_name")
+        sub = layout.row()
+        sub.prop(self, "shape_ext")
         sub = layout.row()
         sub.prop(self, "collision_type")
         sub = layout.row()


### PR DESCRIPTION
This can speed up the work of entering the name and extension for each shape. In this case, the name of the shape will be the same as the name of the object selected in the blender, that is, it is necessary to rename the object (inside the blender) with the same name as the exported shape.